### PR TITLE
Respect ignored channels and users while sending to ws

### DIFF
--- a/main.go
+++ b/main.go
@@ -266,7 +266,9 @@ func main() {
 				}
 
 				toSend.Channel = "#" + channel.Name
-
+			default:
+				// Don't send non-message/typing events to ws
+				return
 			}
 
 			// log message type to ws

--- a/main.go
+++ b/main.go
@@ -271,6 +271,11 @@ func main() {
 				return
 			}
 
+			// Respect ignored channels and users while sending to ws
+			// if !config.ChannelActive(msg.Data.Channel) || !config.UserActive(msg.Data.User) {
+			// 	return
+			// }
+
 			// log message type to ws
 			toSendToWs, err := json.Marshal(toSend)
 			if err != nil {


### PR DESCRIPTION
Two changes:
1. Events that aren't sent as from messages or users typing are no longer pushed
2. (WIP) Channels and users ignored by streambot will be respected by ws and not be included

This removes the need for a manual whitelist here: https://github.com/hackclub/v3/blob/57af30b33fdeca02af0929a88fd6e7f3eb3a1ce9/components/home/slack-events.js#L21-L35