### PR TITLE
link channel in message

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func streamMsg(api *slack.Client, rtm *slack.RTM, ev *slack.MessageEvent) {
 			return
 		}
 
-		channelName = "#" + channel.Name
+		channelName = "<#" + channel.Conversation.ID + ">"
 	}
 
 	attachment := slack.Attachment{


### PR DESCRIPTION
This should link the full channel in the message, instead of just putting the name there